### PR TITLE
Changed key on JournalTransaction to be a proper key

### DIFF
--- a/src/Models/JournalTransaction.php
+++ b/src/Models/JournalTransaction.php
@@ -33,16 +33,6 @@ class JournalTransaction extends Model
     protected $currency = 'USD';
 
     /**
-     * @var bool
-     */
-    public $incrementing = false;
-
-    /**
-     * @var array
-     */
-    protected $guarded=['id'];
-
-    /**
      * @var array
      */
     protected $casts = [
@@ -56,7 +46,7 @@ class JournalTransaction extends Model
     protected static function boot()
     {
         static::creating(function ($transaction) {
-            $transaction->id = \Ramsey\Uuid\Uuid::uuid4()->toString();
+            $transaction->trans_id = \Ramsey\Uuid\Uuid::uuid4()->toString();
         });
 
         static::saved(function ($transaction) {

--- a/src/Services/Accounting.php
+++ b/src/Services/Accounting.php
@@ -3,6 +3,7 @@
 namespace Scottlaurent\Accounting\Services;
 
 use Carbon\Carbon;
+use Scottlaurent\Accounting\Exceptions\TransactionCouldNotBeProcessed;
 use Scottlaurent\Accounting\Models\Journal;
 use Money\Money;
 use Money\Currency;

--- a/src/migrations/2018_09_16_010000_create_accounting_journal_transactions_table.php
+++ b/src/migrations/2018_09_16_010000_create_accounting_journal_transactions_table.php
@@ -32,7 +32,8 @@ class CreateAccountingJournalTransactionsTable extends Migration
         });
 
         Schema::create('accounting_journal_transactions', function (Blueprint $table) {
-            $table->char('id',36)->unique();
+            $table->increments('id');
+            $table->char('trans_id',36)->unique();
             $table->char('transaction_group',36)->nullable();
             $table->integer('journal_id')->unsigned();
             $table->bigInteger('debit')->nullable();

--- a/tests/migrations/2016_05_19_000000_create_accounting_journal_transactions_table.php
+++ b/tests/migrations/2016_05_19_000000_create_accounting_journal_transactions_table.php
@@ -32,7 +32,8 @@ class CreateAccountingJournalTransactionsTable extends Migration
         });
 
         Schema::create('accounting_journal_transactions', function (Blueprint $table) {
-            $table->char('id',36)->unique();
+            $table->increments('id');
+            $table->char('trans_id',36)->unique();
             $table->char('transaction_group',36)->nullable();
             $table->integer('journal_id')->unsigned();
             $table->bigInteger('debit')->nullable();


### PR DESCRIPTION
The table for JournalTransactions used a non-standard key that could not be stored as an entry in a morphed relationship. 

Added a standard incrementing key as 'id' and renamed the old 'id' to 'trans_id'

**NOTE: There are no migrations to do the rename for existing tables! It's only for new databases!**